### PR TITLE
Use GitHub username instead of email

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ $ chmod +x uploadresume.sh
 $ ./uploadresume.sh
 
 
->>Enter your Github email
-yask123@gmail.com
+>>Enter your GitHub username
+yask123
 
 
->>Resume RepoName you wish to give? Your resume will be accessible from http://.github.io/RepoName
+>>Resume RepoName you wish to give? Your resume will be accessible from http://yask123.github.io/RepoName
 myresume
 
 
->>Enter host password for user 'yask123@gmail.com':
+>>Enter host password for user 'yask123':
 *********
 
 >>Enter the complete path of your resume file

--- a/uploadresume.sh
+++ b/uploadresume.sh
@@ -1,6 +1,6 @@
-echo "Enter your Github email"
+echo "Enter your GitHub username"
 read githubid
-echo "Resume RepoName you wish to give? Your resume will be accessible from http://"$github".github.io/RepoName"
+echo "Resume RepoName you wish to give? Your resume will be accessible from http://"$githubid".github.io/RepoName"
 read reponame
 echo curl -u $githubid https://api.github.com/user/repos -d \'{\"name\":\"$reponame\"}\' | bash -
 echo "Enter the complete path of your resume file"
@@ -12,12 +12,12 @@ git init
 git checkout -b gh-pages
 git add .
 git commit -m 'initial commit'
-remoteurl="https://github.com/"${githubid%@*}"/"$reponame
+remoteurl="https://github.com/"${githubid}"/"$reponame
 git remote add origin $remoteurl
 git push origin gh-pages
 
 test=$(python -c "print '$resumepath'.split('/')[-1]")
-url="http://"${githubid%@*}".github.io/"$reponame"/"$test
+url="http://"${githubid}".github.io/"$reponame"/"$test
 echo "Finished, opening resume URL, refresh webpage if you get 404"
 python -m webbrowser $url
 python -m webbrowser "https://twitter.com/intent/tweet?text=Just%20updated%20my%20resume%20on%20Github,%20check%20it%20out%20"$url


### PR DESCRIPTION
Not everyone has a same GitHub username as the local-part of their email address, we cannot rely on that.

As an added benefit of this change, echoing `Your resume will be accessible from http://username.github.io/RepoName` will actually work (now the username part is empty)!
